### PR TITLE
DDFP-19 Upgraded jacoco, checkstyle, dependency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,14 @@
     </parent>
 
     <properties>
-        <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
+        <dependency-check-maven.version>5.3.0</dependency-check-maven.version>
         <jbake.maven.plugin.version>0.0.9</jbake.maven.plugin.version>
-        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
         <maven.install.plugin.version>2.5.2</maven.install.plugin.version>
-        <maven-jacoco-plugin.version>0.8.2</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.8.5</maven-jacoco-plugin.version>
         <maven.javadoc.plugin.version>2.7</maven.javadoc.plugin.version>
         <maven-jaxb2-plugin.version>0.8.2</maven-jaxb2-plugin.version>
         <maven.release.plugin.version>3.0.0-M1</maven.release.plugin.version>
@@ -60,7 +60,6 @@
 
         <!--Project properties-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.report.output.directory>project-info</project.report.output.directory>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.scm.id>github</project.scm.id>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <dependency-check-maven.version>5.3.0</dependency-check-maven.version>
+        <dependency-check-maven.version>5.3.1</dependency-check-maven.version>
         <jbake.maven.plugin.version>0.0.9</jbake.maven.plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>


### PR DESCRIPTION
Upgraded Dependency-check from 5.2.2 to 5.3.1
Upgraded Checkstyle from 3.0.0 to 3.1.1
Upgraded Jacoco from 0.8.2 to 0.8.5

Removed customized project report output directory 

Fixes: #19 

Reviewers 
@codice/build 
@codice/continuous-integration 
@codice/test 
@codice/security 
@TonyMorrison 
@LinkMJB 
@AdamBurstynski 