### PR TITLE
Upgraded maven dependnecy-check verison to 6.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <dependency-check-maven.version>5.3.1</dependency-check-maven.version>
+        <dependency-check-maven.version>6.0.2</dependency-check-maven.version>
         <jbake.maven.plugin.version>0.0.9</jbake.maven.plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>


### PR DESCRIPTION
Upgraded dependency-check version to 6.0.2. Seems most of the changes were database schema related. I did a skim of the release notes but could be missing something else. Most of the maven configuration would be in dependent projects like DDF.

@AdamBurstynski 
@TonyMorrison 
@LinkMJB 
@SmithJosh 